### PR TITLE
[glue-etl][basic] Update the identify event schema for Braze

### DIFF
--- a/glue-etl/src/main/scala/com/circle/data/jobs/BasicUserInfoProcessor.scala
+++ b/glue-etl/src/main/scala/com/circle/data/jobs/BasicUserInfoProcessor.scala
@@ -37,9 +37,9 @@ object BasicUserInfoProcessor
 
     val authData = getDataFrameForGlueCatalog(snapshotDatabase,  "public_auth_user")
     val userProfileData = getDataFrameForGlueCatalog(snapshotDatabase, "public_seedinvest_user_userprofile")
-    val userIdentityData = getDataFrameForGlueCatalog(snapshotDatabase, "public_seedinvest_user_identity")
+    val accreditationStatusData = getDataFrameForGlueCatalog(snapshotDatabase, "public_seedinvest_user_accreditation_status")
 
-    val result = getBasicUserData(authData, userProfileData, userIdentityData, false)
+    val result = getBasicUserData(authData, userProfileData, accreditationStatusData, false)
 
     val timestampKey = LocalDateTime.now.format(DateTimeFormatter.ofPattern("YYYY/MM/dd_HHmmss"))
     val outputPath = s"$outputFileLocation/$timestampKey"

--- a/glue-etl/src/main/scala/com/circle/data/utils/QueryBase.scala
+++ b/glue-etl/src/main/scala/com/circle/data/utils/QueryBase.scala
@@ -28,7 +28,7 @@ object QueryBase {
 
   def getBasicUserData(authData: DataFrame, userProfileData: DataFrame, accreditationStatus: DataFrame, recentOnly: Boolean = false): DataFrame = {
     val selectCols = Array(
-      "profile.user_id AS `userId`",
+      "profile.entity_ptr_id AS `userId`",
       "auth.first_name AS `traits.first_name`",
       "auth.last_name AS `traits.last_name`",
       "auth.email AS `traits.email`",

--- a/glue-etl/src/main/scala/com/circle/data/utils/QueryBase.scala
+++ b/glue-etl/src/main/scala/com/circle/data/utils/QueryBase.scala
@@ -10,38 +10,37 @@ object QueryBase {
   /**
    * Get identify basic user.
    *
-   *  Example Presto Query:
-   *
-      SELECT DISTINCT
-      profile.entity_ptr_id AS "userId"
-      ,COALESCE(ui.first_name, auth.first_name) AS "traits.first_name"
-      ,COALESCE(ui.last_name, auth.last_name) AS "traits.last_name"
-      ,auth.email AS "traits.email"
-      ,ui.phone_number AS "traits.phone"
-      ,profile.email_confirmed AS "traits.email_confirmed"
-      ,profile.date_joined AS "timestamp"
-      FROM auth_user auth
-      INNER JOIN seedinvest_user_userprofile profile ON profile.user_id = auth.id
-      INNER JOIN seedinvest_user_identity ui ON ui.userprofile_id = profile.entity_ptr_id
+      SELECT
+        profile.entity_ptr_id AS "userId",
+        auth.first_name AS "traits.first_name",
+        auth.last_name AS"traits.last_name",
+        auth.email AS "traits.email",
+        auth.date_joined AS "traits.date_joined",
+        auth.last_login AS "traits.last_login",
+        profile.email_confirmed AS "traits.email_confirmed",
+        status.is_accredited AS "traits.is_accredited"
+      FROM public_auth_user auth
+      INNER JOIN public_seedinvest_user_userprofile profile ON profile.user_id = auth.id
+      INNER JOIN public_seedinvest_user_accreditation_status status ON status.userprofile_id = profile.entity_ptr_id
    *
    * @return basic user info
    */
 
-  def getBasicUserData(authData: DataFrame, userProfileData: DataFrame, userIdentityData: DataFrame, recentOnly: Boolean = false): DataFrame = {
+  def getBasicUserData(authData: DataFrame, userProfileData: DataFrame, accreditationStatus: DataFrame, recentOnly: Boolean = false): DataFrame = {
     val selectCols = Array(
       "profile.user_id AS `userId`",
-      "COALESCE(ui.first_name, auth.first_name) AS `traits.first_name`",
-      "COALESCE(ui.last_name, auth.last_name) AS `traits.last_name`",
+      "auth.first_name AS `traits.first_name`",
+      "auth.last_name AS `traits.last_name`",
       "auth.email AS `traits.email`",
+      "auth.date_joined AS `traits.date_joined`",
       "auth.last_login AS `traits.last_login`",
-      "ui.phone_number AS `traits.phone`",
       "profile.email_confirmed AS `traits.email_confirmed`",
-      "profile.date_joined AS `timestamp`"
+      "status.is_accredited AS `traits.is_accredited`"
     )
 
     var result = authData.as("auth")
       .join(userProfileData.as("profile"), col("profile.user_id") === col("auth.id"))
-      .join(userIdentityData.as("ui"), col("ui.userprofile_id") === col("profile.entity_ptr_id"))
+      .join(accreditationStatus.as("status"), col("status.userprofile_id") === col("profile.entity_ptr_id"))
       .selectExpr(selectCols: _*)
 
     if (recentOnly) {

--- a/glue-etl/src/test/scala/com/circle/data/glue/BasicUserInfoProcessorTest.scala
+++ b/glue-etl/src/test/scala/com/circle/data/glue/BasicUserInfoProcessorTest.scala
@@ -27,8 +27,7 @@ class BasicUserInfoProcessorTest
   val profileSchema = List(
     StructField("entity_ptr_id", IntegerType, nullable = true),
     StructField("user_id", IntegerType, nullable = true),
-    StructField("email_confirmed", BooleanType, nullable = true),
-    StructField("date_joined", DateType, nullable = true)
+    StructField("email_confirmed", BooleanType, nullable = true)
   )
 
   val authSchema = List(
@@ -36,32 +35,31 @@ class BasicUserInfoProcessorTest
     StructField("first_name", StringType, nullable = true),
     StructField("last_name", StringType, nullable = true),
     StructField("email", StringType, nullable = true),
-    StructField("last_login", DateType, nullable = true)
+    StructField("last_login", DateType, nullable = true),
+    StructField("date_joined", DateType, nullable = true)
   )
 
-  val uiSchema = List(
+  val statusSchema = List(
     StructField("userprofile_id", IntegerType, nullable = true),
-    StructField("first_name", StringType, nullable = true),
-    StructField("last_name", StringType, nullable = true),
-    StructField("phone_number", StringType, nullable = true)
+    StructField("is_accredited", BooleanType, nullable = true)
   )
 
   val profileData = Seq(
-    Row(211921, 193663, true, null),
-    Row(469225, 412193, false, null),
-    Row(431253, 450024, true, null)
+    Row(211921, 193663, true),
+    Row(469225, 412193, false),
+    Row(431253, 450024, true)
   )
 
   val authData = Seq(
-    Row(193663, "Rodney", "Smith", "rodne@sor.com", null),
-    Row(412193, "Charles", "Yeo", "char@atotech.com", null),
-    Row(450024, "Nicholas", "Lu", "nick@ged.com", null)
+    Row(193663, "Rodney", "Smith", "rodne@sor.com", null, null),
+    Row(412193, "Charles", "Yeo", "char@atotech.com", null, null),
+    Row(450024, "Nicholas", "Lu", "nick@ged.com", null, null)
   )
   
-  val uiData = Seq(
-    Row(211921, null, null, null),
-    Row(469225, null, null, "1234567891"),
-    Row(431253, null, null, "2345670987")
+  val statusData = Seq(
+    Row(211921, true),
+    Row(469225, false),
+    Row(431253, true)
   )
 
   test("Test basic user info") {
@@ -76,12 +74,12 @@ class BasicUserInfoProcessorTest
       StructType(authSchema)
     )
 
-    val uiDF = spark.createDataFrame(
-      sparkContext.parallelize(uiData),
-      StructType(uiSchema)
+    val statusDF = spark.createDataFrame(
+      sparkContext.parallelize(statusData),
+      StructType(statusSchema)
     )
 
-    val results = getBasicUserData(authDF, profileDF, uiDF, false)
+    val results = getBasicUserData(authDF, profileDF, statusDF, false)
 
     assert(results.count() == 3)
 

--- a/lambda/basic/index.js
+++ b/lambda/basic/index.js
@@ -30,9 +30,10 @@ const Analytics = require('analytics-node');
 const analytics = new Analytics(process.env.write_key);
 
 function transform(obj) {
-  if (obj.timestamp) {
-    obj.timestamp = new Date(obj.timestamp);
-  }
+  // Add timestamp, created_at and messgeId for identify events
+  obj.timestamp = new Date();
+  obj.messageId = `db-identify-${obj.userId}`;
+  obj.traits.created_at = obj.traits.date_joined;
   return obj;
 };
 

--- a/lambda/basic/package.json
+++ b/lambda/basic/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "analytics-node": "^6.0.0",
     "async": "^3.2.2",
-    "csvtojson": "^2.0.10",
-    "npm": "^8.5.5"
+    "csvtojson": "^2.0.10"
   }
 }


### PR DESCRIPTION
1. Update the identify event schema for Braze include the query and comments. Remove the unnecessary seedinvest_user_identity table.
2. Update test. 
3. Update the basic lambda.