### PR TITLE
[glue-etl][lambda] Add the lambda and update the scala job for email preference

### DIFF
--- a/glue-etl/src/main/scala/com/circle/data/glue/DataLoader.scala
+++ b/glue-etl/src/main/scala/com/circle/data/glue/DataLoader.scala
@@ -54,6 +54,16 @@ trait DataLoader extends Logging {
     getDynamicFrameForGlueCatalog(database, table, transformationContext).toDF()
   }
 
+  def getDataFrameForGlueCatalog(databaseTable: String)
+                                (implicit context: GlueContext): DataFrame = {
+    databaseTable.split("""\.""") match {
+      case Array(database, table) =>
+        getDynamicFrameForGlueCatalog(database, table).toDF()
+      case _ =>
+        throw new IllegalArgumentException(s"can't parse table name $databaseTable")
+    }
+  }
+
   def getDynamicFrameForGlueCatalog(database: String, table: String, transformationContext: String = "loading source data")
                                    (implicit context: GlueContext): DynamicFrame = {
     context.getCatalogSource(

--- a/glue-etl/src/main/scala/com/circle/data/glue/DataLoader.scala
+++ b/glue-etl/src/main/scala/com/circle/data/glue/DataLoader.scala
@@ -54,13 +54,16 @@ trait DataLoader extends Logging {
     getDynamicFrameForGlueCatalog(database, table, transformationContext).toDF()
   }
 
-  def getDataFrameForGlueCatalog(databaseTable: String)
+  /**
+   * Get the dataframe from the table name with database name like "siservices_prod_db.public_auth_user"
+   */
+  def getDataFrameForGlueCatalog(databaseTableName: String)
                                 (implicit context: GlueContext): DataFrame = {
-    databaseTable.split("""\.""") match {
+    databaseTableName.split("""\.""") match {
       case Array(database, table) =>
         getDynamicFrameForGlueCatalog(database, table).toDF()
       case _ =>
-        throw new IllegalArgumentException(s"can't parse table name $databaseTable")
+        throw new IllegalArgumentException(s"can't parse table name $databaseTableName")
     }
   }
 

--- a/glue-etl/src/main/scala/com/circle/data/jobs/EmailPreferenceProcessor.scala
+++ b/glue-etl/src/main/scala/com/circle/data/jobs/EmailPreferenceProcessor.scala
@@ -29,17 +29,24 @@ object EmailPreferenceProcessor
     logConfiguration()
 
     val options = initializeJob(context, args,
-      Array(SourceGlueDatabaseParam, OutputLocationParam)
+      Array(OutputLocationParam)
     )
 
-    val snapshotDatabase = options(SourceGlueDatabaseParam)
     val outputFileLocation = options(OutputLocationParam)
 
-    val preferenceRuleData = getDataFrameForGlueCatalog(snapshotDatabase, "public_ponyexpress_preference_rule")
-    val contactChannelData = getDataFrameForGlueCatalog(snapshotDatabase, "public_ponyexpress_preferences_contact_channel")
-    val preferenceData = getDataFrameForGlueCatalog(snapshotDatabase, "public_ponyexpress_preferences_preference")
+    val authData = getDataFrameForGlueCatalog(databaseTable = "siservices_prod_db.public_auth_user")
+    val profileData = getDataFrameForGlueCatalog(databaseTable = "siservices_prod_db.public_seedinvest_user_userprofile")
+    val preferenceRuleData = getDataFrameForGlueCatalog(databaseTable = "investorcrm_db.public_ponyexpress_preference_rule")
+    val contactChannelData = getDataFrameForGlueCatalog(databaseTable = "investorcrm_db.public_ponyexpress_preferences_contact_channel")
+    val preferenceData = getDataFrameForGlueCatalog(databaseTable = "investorcrm_db.public_ponyexpress_preferences_preference")
 
-    val result = getEmailPreferenceData(preferenceRuleData, contactChannelData, preferenceData)
+    val result = getEmailPreferenceData(
+      authData = authData,
+      profileData = profileData,
+      preferenceRuleData = preferenceRuleData,
+      contactChannelData = contactChannelData,
+      preferenceData = preferenceData
+    )
 
     val timestampKey = LocalDateTime.now.format(DateTimeFormatter.ofPattern("YYYY/MM/dd_HHmmss"))
     val outputPath = s"$outputFileLocation/$timestampKey"

--- a/glue-etl/src/main/scala/com/circle/data/jobs/EmailPreferenceProcessor.scala
+++ b/glue-etl/src/main/scala/com/circle/data/jobs/EmailPreferenceProcessor.scala
@@ -34,11 +34,11 @@ object EmailPreferenceProcessor
 
     val outputFileLocation = options(OutputLocationParam)
 
-    val authData = getDataFrameForGlueCatalog(databaseTable = "siservices_prod_db.public_auth_user")
-    val profileData = getDataFrameForGlueCatalog(databaseTable = "siservices_prod_db.public_seedinvest_user_userprofile")
-    val preferenceRuleData = getDataFrameForGlueCatalog(databaseTable = "investorcrm_db.public_ponyexpress_preference_rule")
-    val contactChannelData = getDataFrameForGlueCatalog(databaseTable = "investorcrm_db.public_ponyexpress_preferences_contact_channel")
-    val preferenceData = getDataFrameForGlueCatalog(databaseTable = "investorcrm_db.public_ponyexpress_preferences_preference")
+    val authData = getDataFrameForGlueCatalog(databaseTableName = "siservices_prod_db.public_auth_user")
+    val profileData = getDataFrameForGlueCatalog(databaseTableName = "siservices_prod_db.public_seedinvest_user_userprofile")
+    val preferenceRuleData = getDataFrameForGlueCatalog(databaseTableName = "investorcrm_db.public_ponyexpress_preference_rule")
+    val contactChannelData = getDataFrameForGlueCatalog(databaseTableName = "investorcrm_db.public_ponyexpress_preferences_contact_channel")
+    val preferenceData = getDataFrameForGlueCatalog(databaseTableName = "investorcrm_db.public_ponyexpress_preferences_preference")
 
     val result = getEmailPreferenceData(
       authData = authData,

--- a/glue-etl/src/main/scala/com/circle/data/utils/QueryBase.scala
+++ b/glue-etl/src/main/scala/com/circle/data/utils/QueryBase.scala
@@ -131,7 +131,7 @@ object QueryBase {
       .filter(col("active") === "true")
       .selectExpr(selectCols: _*)
       // Make sure the email has right format
-      .filter(col("email").rlike("""^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})$"""))
+      .filter(col("email").rlike("""^(\S+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]+)$"""))
       // Collect all the subscriptiona for a user
       .groupBy("userId", "email")
       .agg(

--- a/glue-etl/src/test/scala/com/circle/data/glue/EmailPreferenceProcessorTest.scala
+++ b/glue-etl/src/test/scala/com/circle/data/glue/EmailPreferenceProcessorTest.scala
@@ -24,10 +24,25 @@ import utils.ETLSuiteBase
 class EmailPreferenceProcessorTest
   extends ETLSuiteBase {
 
+  val authSchema = List(
+    StructField("id", IntegerType, nullable = true),
+    StructField("first_name", StringType, nullable = true),
+    StructField("last_name", StringType, nullable = true),
+    StructField("email", StringType, nullable = true),
+    StructField("last_login", DateType, nullable = true),
+    StructField("date_joined", DateType, nullable = true)
+  )
+
+  val profileSchema = List(
+    StructField("entity_ptr_id", IntegerType, nullable = true),
+    StructField("user_id", IntegerType, nullable = true),
+    StructField("email_confirmed", BooleanType, nullable = true)
+  )
+
   val ruleSchema = List(
     StructField("id", IntegerType, nullable = true),
-    StructField("created_at", DateType, nullable = true),
-    StructField("modified_at", DateType, nullable = true),
+    StructField("created_at", StringType, nullable = true),
+    StructField("modified_at", StringType, nullable = true),
     StructField("active", BooleanType, nullable = true),
     StructField("contact_channel_id", IntegerType, nullable = true),
     StructField("preference_id", IntegerType, nullable = true)
@@ -46,26 +61,55 @@ class EmailPreferenceProcessorTest
     StructField("display_label", StringType, nullable = true)
   )
 
+  val profileData = Seq(
+    Row(211921, 193663, true),
+    Row(469225, 412193, false),
+    Row(431253, 450024, true),
+    Row(431254, 450025, true),
+    Row(431255, 450026, true)
+  )
+
+  val authData = Seq(
+    Row(193663, "Rodney", "Smith", "rodne@sor.com", null, null),
+    Row(412193, "Charles", "Yeo", "char@atotech.com.uk", null, null),
+    Row(450024, "Nicholas", "Lu", "nick@ged.com", null, null),
+    Row(450025, "Nicholas", "Lu", "foobar@", null, null),
+    Row(450026, "Jay", "Han", "foobar", null, null)
+  )
+
   val ruleData = Seq(
-    Row(1, null, null, true, 11, 21),
-    Row(2, null, null, false, 12, 22),
+    Row(1, null, "2022-04-08T20:33:04.338Z", true, 11, 21),
+    Row(2, null, "2022-04-18T20:33:04.338Z", true, 12, 22),
     Row(3, null, null, true, 13, 22),
-    Row(4, null, null, false, 14, 22)
+    Row(4, null, null, false, 14, 22),
+    Row(5, null, "2022-04-18T20:33:04.338Z", true, 11, 22),
+    Row(5, null, "2022-04-18T20:33:04.338Z", false, 11, 23)
   )
 
   val channelData = Seq(
-    Row(11, "marketing", "foo@bar.com"),
-    Row(12, "marketing", "foo1@bar.bar.com"),
+    Row(11, "marketing", "rodne@sor.com"),
+    Row(12, "marketing", "char@atotech.com.uk"),
     Row(13, "marketing", "foobar@"),
     Row(14, "marketing", "foobar")
   )
   
   val preferenceData = Seq(
     Row(21, "weekly_news_letter", "weekly_news_letter", "Weekly News Letter"),
-    Row(22, "monthly_news_letter", "monthly_news_letter", "Monthly News Letter")
+    Row(22, "monthly_news_letter", "monthly_news_letter", "Monthly News Letter"),
+    Row(23, "corp1", "corp1", "Corp1")
   )
 
   test("Test email preference") {
+
+    val authDF = spark.createDataFrame(
+      sparkContext.parallelize(authData),
+      StructType(authSchema)
+    )
+
+    val profileDF = spark.createDataFrame(
+      sparkContext.parallelize(profileData),
+      StructType(profileSchema)
+    )
 
     val ruleDF = spark.createDataFrame(
       sparkContext.parallelize(ruleData),
@@ -82,7 +126,7 @@ class EmailPreferenceProcessorTest
       StructType(preferenceSchema)
     )
 
-    val results = getEmailPreferenceData(ruleDF, channelDF, preferenceDF)
+    val results = getEmailPreferenceData(authDF, profileDF, ruleDF, channelDF, preferenceDF)
 
     assert(results.count() == 2)
 

--- a/lambda/emailpreference/index.js
+++ b/lambda/emailpreference/index.js
@@ -14,13 +14,10 @@
 
 /**
  * A lambda for to sync CSV files on S3 to Segment.
- *
- * See design doc:
- * https://docs.google.com/document/d/1yBsv0ECwitoieDWH8aB5Pt1mc8G6-SPJuok3s_W_Ox8/
+ * Load the email preferences and send identify events to Segment.
  */
 
 // dependencies
-// const async = require('async');
 const AWS = require('aws-sdk');
 const csv = require('csvtojson');
 const s3 = new AWS.S3();

--- a/lambda/emailpreference/index.js
+++ b/lambda/emailpreference/index.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 Circle Internet Financial Trading Company Limited.
+ * All rights reserved.
+ *
+ * Circle Internet Financial Trading Company Limited CONFIDENTIAL
+ *
+ * This repository includes unpublished proprietary source code of Circle Internet
+ * Financial Trading Company Limited, Inc. The copyright notice above does not
+ * evidence any actual or intended publication of such source code. Disclosure
+ * of this source code or any related proprietary information is strictly
+ * prohibited without the express written permission of Circle Internet Financial
+ * Trading Company Limited.
+ */
+
+/**
+ * A lambda for to sync CSV files on S3 to Segment.
+ *
+ * See design doc:
+ * https://docs.google.com/document/d/1yBsv0ECwitoieDWH8aB5Pt1mc8G6-SPJuok3s_W_Ox8/
+ */
+
+// dependencies
+// const async = require('async');
+const AWS = require('aws-sdk');
+const csv = require('csvtojson');
+const s3 = new AWS.S3();
+
+// the following are Segment libraries
+const Analytics = require('analytics-node');
+const analytics = new Analytics(process.env.write_key);
+
+function transform(obj) {
+  
+  obj.messageId = `db-identify-email-${obj.userId}`;
+  
+  const ts = new Date(obj.timestamp);
+  obj.timestamp = ts;
+
+  obj.traits = {};
+  const subscribed = obj.subscribed.split(' ');
+  subscribed.forEach(topic => obj.traits[`${topic}`] = 'true')
+  delete obj.subscribed;
+
+  obj.traits.email = obj.email;
+  delete obj.email;
+  return obj;
+};
+
+exports.handler = function (event, context, callback) {
+  const srcBucket = event.Records[0].s3.bucket.name;
+  const srcFileName = event.Records[0].s3.object.key;
+
+  const params = {
+    Bucket: srcBucket,
+    Key: srcFileName,
+  };
+
+  csv()
+    .fromStream(s3.getObject(params).createReadStream())
+    .subscribe((json) => {
+      const event = transform(json);
+      console.log(event);
+      analytics.identify(event);
+    }, (err) => {
+      console.error(err);
+    }, async () => {});
+};

--- a/lambda/emailpreference/package-lock.json
+++ b/lambda/emailpreference/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdp-investor-action-to-segment",
+  "name": "cdp-email-preference-to-segment",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/lambda/emailpreference/package-lock.json
+++ b/lambda/emailpreference/package-lock.json
@@ -1,0 +1,151 @@
+{
+  "name": "cdp-investor-action-to-segment",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@segment/loosely-validate-event": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
+      "integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+      "requires": {
+        "component-type": "^1.2.1",
+        "join-component": "^1.1.0"
+      }
+    },
+    "analytics-node": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-6.0.0.tgz",
+      "integrity": "sha512-qhwB5Fl/ps7VTg1/RnD3qJohceSHUjzTBqNn3DCmQZu/AdgPbGPeNFYu2o3xIuIyq+xZElrv0Do0b/zuGxBL9g==",
+      "requires": {
+        "@segment/loosely-validate-event": "^2.0.0",
+        "axios": "^0.21.4",
+        "axios-retry": "3.2.0",
+        "lodash.isstring": "^4.0.1",
+        "md5": "^2.2.1",
+        "ms": "^2.0.0",
+        "remove-trailing-slash": "^0.1.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "async": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+    },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "axios-retry": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.0.tgz",
+      "integrity": "sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==",
+      "requires": {
+        "is-retry-allowed": "^1.1.0"
+      }
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
+    "component-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
+      "integrity": "sha1-ikeQFwAjjk/DIml3EjAibyS0Fak="
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+    },
+    "csvtojson": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.10.tgz",
+      "integrity": "sha512-lUWFxGKyhraKCW8Qghz6Z0f2l/PqB1W3AO0HKJzGIQ5JRSlR651ekJDiGJbBT4sRNNv5ddnSGVEnsxP9XRCVpQ==",
+      "requires": {
+        "bluebird": "^3.5.1",
+        "lodash": "^4.17.3",
+        "strip-bom": "^2.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-retry-allowed": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "join-component": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
+      "integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "remove-trailing-slash": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz",
+      "integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA=="
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    }
+  }
+}

--- a/lambda/emailpreference/package.json
+++ b/lambda/emailpreference/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cdp-investor-action-to-segment",
+  "name": "cdp-email-preference-to-segment",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/lambda/emailpreference/package.json
+++ b/lambda/emailpreference/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cdp-investor-action-to-segment",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "analytics-node": "^6.0.0",
+    "async": "^3.2.2",
+    "csvtojson": "^2.0.10"
+  }
+}

--- a/lambda/emailpreference/release-dev.sh
+++ b/lambda/emailpreference/release-dev.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+rm -f /tmp/package.zip
+zip -x release-dev.sh -r /tmp/package.zip .
+
+aws lambda get-function --function-name cdp-email-preference-segment-dev 1>/dev/null 
+if [[ $? -eq 0 ]] 
+then
+    aws lambda update-function-code --function-name cdp-email-preference-segment-dev --zip-file fileb:///tmp/package.zip
+else 
+    aws lambda create-function --function-name cdp-email-preference-segment-dev --zip-file fileb:///tmp/package.zip --role arn:aws:iam::301027959319:role/segment-dev-lambda-s3-role --runtime nodejs14.x --handler index.handler
+fi


### PR DESCRIPTION
1. Make a generic getDataFrameForGlueCatalog function to load the table with database name.
2. Update the email preference job to join with the profile tables which is across databases.
3. Update tests.
4. Add lambda for email preference identify events.
